### PR TITLE
Update fluentd version to 1.10

### DIFF
--- a/fluentd-coralogix-image/Dockerfile
+++ b/fluentd-coralogix-image/Dockerfile
@@ -1,5 +1,5 @@
 # Set FluentD version
-ARG FLUENTD_VERSION=v1.8-1
+ARG FLUENTD_VERSION=v1.10.0-1.0
 
 # Extend official FluentD image
 FROM fluent/fluentd:${FLUENTD_VERSION}


### PR DESCRIPTION
I've upgrade the fluentd image to version 1.10,
I am not sure what is your test/build/deploy process so I don't know how to really progress here.

But this version includes some fixes we should support:
1. server: Add cert_verifier parameter for TLS transport https://github.com/fluent/fluentd/pull/2888
1. parser_syslog: Support customized time format https://github.com/fluent/fluentd/pull/2886
1. parser_syslog: Fix syslog format detection https://github.com/fluent/fluentd/pull/2879
1. parser_syslog: Add multiline RFC5424 support https://github.com/fluent/fluentd/pull/2767