### PR TITLE
#Bug Daemonset resources not specified

### DIFF
--- a/examples/helm/templates/daemonset.yaml
+++ b/examples/helm/templates/daemonset.yaml
@@ -42,7 +42,7 @@ spec:
         - secretRef:
            name: {{ template "coralogix-fluentd.name" . }}-account-secrets
         resources:
-{{ toYaml .Values.resources | indent 10 }}
+{{ toYaml .Values.container.resources | indent 10 }}
         volumeMounts:
         - name: varlog
           mountPath: /var/log


### PR DESCRIPTION
Bug:
The resources variable link in the templates/daemonset.yaml is wrong.

Impact:
Serious Bug that can throttle the main application pods, seriously degrade app performance and make entire cluster unstable as specifying no resources gives the coralogix fluentd daemonset pods access to unlimited resource utilization on the node.