### PR TITLE
Remove concat filter

### DIFF
--- a/examples/helm/templates/configmap.yaml
+++ b/examples/helm/templates/configmap.yaml
@@ -231,14 +231,6 @@ data:
         </record>
       </filter>
       <filter **>
-        @type concat
-        key log
-        stream_identity_key container_id
-        multiline_end_regexp /\n$/
-        separator " "
-        flush_interval 30
-      </filter>
-      <filter **>
         @type record_transformer
         remove_keys container_id
       </filter>

--- a/fluentd-coralogix-image/Dockerfile
+++ b/fluentd-coralogix-image/Dockerfile
@@ -27,7 +27,6 @@ RUN apk add --no-cache --update --virtual .build-deps build-base ruby-dev && \
                 fluent-plugin-systemd \
                 fluent-plugin-multi-format-parser \
                 fluent-plugin-rewrite-tag-filter \
-                fluent-plugin-concat \
                 fluent-plugin-detect-exceptions \
                 fluent-plugin-coralogix && \
     gem sources --clear-all && \


### PR DESCRIPTION
Since this breaks logs in k8s 19 (according to our experience) and based on your advice, this should be removed from the helm chart