### PR TITLE
Release coralogix-image for Linux/ARM64 through TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: true
-dist: trusty
+dist: focal
 env:
   - VERSION=$TRAVIS_TAG
 services:
@@ -22,15 +22,21 @@ jobs:
         - docker-compose --project-directory=$TRAVIS_BUILD_DIR up -d
       after_script:
         - docker-compose --project-directory=$TRAVIS_BUILD_DIR down
-    - stage: push docker image
+    - stage: build_push docker image
       install: skip
-      script:
-        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        - make publish
+      before_install: 
+        - mkdir -p ~/.docker/cli-plugins
+        - wget -O - https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64 > ~/.docker/cli-plugins/docker-buildx
+        - chmod a+x ~/.docker/cli-plugins/docker-buildx
+        - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        - docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
+      script: make build_push
+
 stages:
   - build docker image
   - test docker image
-  - name: push docker image
+  - build_push docker image
+  - name: build_push docker image
     if: branch = master AND type = push
 
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY:	publish
+.PHONY:	all
 
 PREFIX = coralogixrepo
 IMAGE = fluentd-coralogix-image
@@ -10,9 +10,7 @@ build:
 		--tag $(PREFIX)/$(IMAGE):$(TAG) \
 		--build-arg VERSION=$(TAG) \
 		./$(IMAGE)
-
-push:
-	docker push $(PREFIX)/$(IMAGE):latest
-	docker push $(PREFIX)/$(IMAGE):$(TAG)
-
-publish: build push
+build_push:
+	docker buildx create --use --name mybuilder
+	docker buildx build -t $(PREFIX)/$(IMAGE):latest --platform linux/arm64,linux/amd64 --push ./$(IMAGE)
+	docker buildx rm mybuilder


### PR DESCRIPTION
The following file has been modified:
Added buildx support in Makefile to release docker image for arm64 and amd64 platforms using TravisCI.
Signed-off-by: odidev <odidev@puresoftware.com>